### PR TITLE
Enable peril to add labels to old PRs

### DIFF
--- a/danger/pr.ts
+++ b/danger/pr.ts
@@ -1,0 +1,20 @@
+import {schedule, danger} from "danger";
+
+declare const peril : any
+const gh = danger.github
+const pr = gh.pr
+const repo = gh.repository
+const api = danger.github.api
+const pr_date = pr.created_at
+const now = new Date()
+const weekAgo = now.setDate(now.getDay() - 7)
+
+if (Date.parse(pr_date) < weekAgo) {
+    schedule(async() => {
+        await api.pr.addLabels({
+          owner: repo.owner.login,
+          repo: repo.name,
+          number: pr.number,
+          labels: ["needs attention"]})
+    });
+}

--- a/danger/pr.ts
+++ b/danger/pr.ts
@@ -1,4 +1,5 @@
 import {schedule, danger} from "danger";
+import {gh, repo, api} from './regressions'
 
 declare const peril : any
 const gh = danger.github
@@ -11,10 +12,8 @@ const weekAgo = now.setDate(now.getDay() - 7)
 
 if (Date.parse(pr_date) < weekAgo) {
     schedule(async() => {
-        await api.pr.addLabels({
-          owner: repo.owner.login,
-          repo: repo.name,
-          number: pr.number,
-          labels: ["needs attention"]})
+        await api
+            .pr
+            .addLabels({owner: repo.owner.login, repo: repo.name, number: pr.number, labels: ["needs attention"]})
     });
 }

--- a/danger/pr.ts
+++ b/danger/pr.ts
@@ -1,7 +1,5 @@
 import {schedule, danger} from "danger";
-import {gh, repo, api} from './regressions'
 
-declare const peril : any
 const gh = danger.github
 const pr = gh.pr
 const repo = gh.repository
@@ -12,8 +10,10 @@ const weekAgo = now.setDate(now.getDay() - 7)
 
 if (Date.parse(pr_date) < weekAgo) {
     schedule(async() => {
-        await api
-            .pr
-            .addLabels({owner: repo.owner.login, repo: repo.name, number: pr.number, labels: ["needs attention"]})
+        await api.pr.addLabels({
+          owner: repo.owner.login,
+          repo: repo.name,
+          number: pr.number,
+          labels: ["needs attention"]})
     });
 }

--- a/settings.json
+++ b/settings.json
@@ -5,7 +5,7 @@
   },
   "rules": {
     // https://artsy.github.io/blog/2017/09/04/Introducing-Peril/#Events
-    "issues.opened": "fastlane/peril-settings@danger/regressions.ts"
+    "issues.opened": "fastlane/peril-settings@danger/regressions.ts",
     "pull_request": "fastlane/peril-settings@danger/pr.ts"
   }
 }

--- a/settings.json
+++ b/settings.json
@@ -6,5 +6,6 @@
   "rules": {
     // https://artsy.github.io/blog/2017/09/04/Introducing-Peril/#Events
     "issues.opened": "fastlane/peril-settings@danger/regressions.ts"
+    "pull_request": "fastlane/peril-settings@danger/pr.ts"
   }
 }


### PR DESCRIPTION
This is a fix to this [issue](https://github.com/fastlane/ci/issues/971) on Fastlane CI. It provides a way for peril to add a `needs attention` label to Pull Requests which are older than 7 days.